### PR TITLE
Make string type implement stringer interface

### DIFF
--- a/string.go
+++ b/string.go
@@ -60,3 +60,13 @@ func (s String) interfaceValue() interface{} {
 func (s String) IsEmpty() bool {
 	return s.set && s.value != nil && strings.TrimSpace(*s.value) == ""
 }
+
+func (s String) String() string {
+	if s.Removed() {
+		return "<removed>"
+	}
+	if !s.IsSet() {
+		return "<unset>"
+	}
+	return *s.Value()
+}

--- a/string_test.go
+++ b/string_test.go
@@ -207,3 +207,19 @@ func TestString_Value(t *testing.T) {
 		t.Errorf("Expected: %v, Actual: %v", expected, *s.Value())
 	}
 }
+
+func TestString_String(t *testing.T) {
+	var s String
+	if s.String() != "<unset>" {
+		t.Errorf("Expected: <unset>, Actual: %v", s.String())
+	}
+	s.SetPtr(nil)
+	if s.String() != "<removed>" {
+		t.Errorf("Expected: <removed>, Actual: %v", s.String())
+	}
+	expected := "value"
+	s.SetValue(expected)
+	if s.String() != expected {
+		t.Errorf("Expected: %v, Actual: %v", expected, s.String())
+	}
+}


### PR DESCRIPTION
<!--
	Niche Back-End PR Template
	Don't Forget:
	- Add your PR to any relevant github boards
	- Tag your PR with the BACK_END label
-->

<!-- CC relevant team members -->

### Depends On

<!-- Does this PR depend on other PRs in the pipeline? Same service, other services, go-common etc.  If
  it depends on other PRs within the same repository, link github diffs between these PRs for ease of review -->

n/a

### Documentation

<!-- Link(s) to documentation relevant to the work, such as issues, wiki, tech debt cards, etc. -->

n/a

### Description

<!-- A plain-English overview of the work involved in this PR. -->

It would be nice to implement the stringer interface in places where the underlying type implements the stringer interface. There might be an elegant way to do this for all relevant types in one go, but for the moment it seems reasonable to start with the string type.

### Testing Considerations

<!-- Any specific testing considerations for this PR: dependencies, sample UUIDs, test data etc.-->

n/a

### SQL Migrations

<!-- List any required SQL migrations with links to specific migration scripts.-->

n/a

### Deployment 

<!-- Any deployment considerations for this PR, including new service flags, dependencies, necessary order of operations etc. -->

<!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->

n/a

### Versioning

<!-- Indicate whether this is a Major, Minor, or Patch bump and explain why. -->

Minor