### PR TITLE
Clean up golint warnings and remove coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # nullable
 
 [![Build Status](https://github.com/nicheinc/nullable/actions/workflows/ci.yml/badge.svg)](https://github.com/nicheinc/nullable/actions/workflows/ci.yml)
-[![Coverage Status](https://coveralls.io/repos/github/nicheinc/nullable/badge.svg?branch=main)](https://coveralls.io/github/nicheinc/nullable?branch=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nicheinc/nullable)](https://goreportcard.com/report/github.com/nicheinc/nullable)
 [![Godoc](https://godoc.org/github.com/nicheinc/nullable?status.svg)](https://godoc.org/github.com/nicheinc/nullable) 
 [![license](https://img.shields.io/github/license/nicheinc/nullable.svg?cacheSeconds=2592000)](LICENSE)

--- a/bool.go
+++ b/bool.go
@@ -77,6 +77,7 @@ func (b Bool) Diff(value bool) Bool {
 	return b
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
 func (b *Bool) UnmarshalJSON(data []byte) error {
 	b.set = true
 	return json.Unmarshal(data, &b.value)
@@ -92,6 +93,7 @@ func (b Bool) Removed() bool {
 	return b.set && b.value == nil
 }
 
+// InterfaceValue returns value as an interface{}.
 func (b Bool) InterfaceValue() interface{} {
 	return b.value
 }

--- a/float64.go
+++ b/float64.go
@@ -8,7 +8,7 @@ type Float64 struct {
 	value *float64
 }
 
-// NewInt returns a Float64 set to the given value.
+// NewFloat64 returns a Float64 set to the given value.
 func NewFloat64(v float64) Float64 {
 	return Float64{
 		set:   true,
@@ -16,7 +16,7 @@ func NewFloat64(v float64) Float64 {
 	}
 }
 
-// NewIntPtr returns a Float64 set to the given pointer.
+// NewFloat64Ptr returns a Float64 set to the given pointer.
 func NewFloat64Ptr(v *float64) Float64 {
 	return Float64{
 		set:   true,
@@ -25,20 +25,20 @@ func NewFloat64Ptr(v *float64) Float64 {
 }
 
 // SetValue modifies the receiver to be an update to the given value.
-func (i *Float64) SetValue(value float64) {
-	i.SetPtr(&value)
+func (f *Float64) SetValue(value float64) {
+	f.SetPtr(&value)
 }
 
 // SetPtr modifies the receiver to be an update to the given value. If the value
 // is nil, the receiver will be removed.
-func (i *Float64) SetPtr(value *float64) {
-	i.set = true
-	i.value = value
+func (f *Float64) SetPtr(value *float64) {
+	f.set = true
+	f.value = value
 }
 
 // Value returns nil if the receiver is unset/removed or else the updated value.
-func (i Float64) Value() *float64 {
-	return i.value
+func (f Float64) Value() *float64 {
+	return f.value
 }
 
 // Equals returns whether the receiver is set to the given value.
@@ -77,31 +77,33 @@ func (f Float64) Diff(value float64) Float64 {
 	return f
 }
 
-func (i *Float64) UnmarshalJSON(data []byte) error {
-	i.set = true
-	return json.Unmarshal(data, &i.value)
+// UnmarshalJSON implements json.Unmarshaler.
+func (f *Float64) UnmarshalJSON(data []byte) error {
+	f.set = true
+	return json.Unmarshal(data, &f.value)
 }
 
 // IsSet returns true if the receiver has been set/removed.
-func (i Float64) IsSet() bool {
-	return i.set
+func (f Float64) IsSet() bool {
+	return f.set
 }
 
 // Removed returns whether the receiver has been removed (value set to nil).
-func (i Float64) Removed() bool {
-	return i.set && i.value == nil
+func (f Float64) Removed() bool {
+	return f.set && f.value == nil
 }
 
-func (i Float64) InterfaceValue() interface{} {
-	return i.value
+// InterfaceValue returns value as an interface{}.
+func (f Float64) InterfaceValue() interface{} {
+	return f.value
 }
 
 // IsZero returns whether the receiver is set to 0.
-func (i Float64) IsZero() bool {
-	return i.set && i.value != nil && *i.value == 0.0
+func (f Float64) IsZero() bool {
+	return f.set && f.value != nil && *f.value == 0.0
 }
 
 // IsNegative returns whether the receiver is set to a negative value.
-func (i Float64) IsNegative() bool {
-	return i.set && i.value != nil && *i.value < 0.0
+func (f Float64) IsNegative() bool {
+	return f.set && f.value != nil && *f.value < 0.0
 }

--- a/int.go
+++ b/int.go
@@ -77,6 +77,7 @@ func (i Int) Diff(value int) Int {
 	return i
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
 func (i *Int) UnmarshalJSON(data []byte) error {
 	i.set = true
 	return json.Unmarshal(data, &i.value)
@@ -92,6 +93,7 @@ func (i Int) Removed() bool {
 	return i.set && i.value == nil
 }
 
+// InterfaceValue returns value as an interface{}.
 func (i Int) InterfaceValue() interface{} {
 	return i.value
 }

--- a/marshalJSON.go
+++ b/marshalJSON.go
@@ -51,7 +51,7 @@ func MarshalJSON(v interface{}) ([]byte, error) {
 			// well as a leading comma if this isn't the first field marshalled.
 			capacity := len(*key) + len(valueBuf) + 3
 			if prependComma {
-				capacity += 1
+				capacity++
 			}
 			fieldBuf := make([]byte, 0, capacity)
 			// Append the components of the field data.

--- a/string.go
+++ b/string.go
@@ -80,6 +80,7 @@ func (s String) Diff(value string) String {
 	return s
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
 func (s *String) UnmarshalJSON(data []byte) error {
 	s.set = true
 	return json.Unmarshal(data, &s.value)
@@ -95,6 +96,7 @@ func (s String) Removed() bool {
 	return s.set && s.value == nil
 }
 
+// InterfaceValue returns value as an interface{}.
 func (s String) InterfaceValue() interface{} {
 	return s.value
 }

--- a/stringSlice.go
+++ b/stringSlice.go
@@ -67,6 +67,7 @@ func (s StringSlice) Diff(value []string) StringSlice {
 	return s
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
 func (s *StringSlice) UnmarshalJSON(data []byte) error {
 	s.set = true
 	return json.Unmarshal(data, &s.value)
@@ -82,6 +83,7 @@ func (s StringSlice) Removed() bool {
 	return s.set && s.value == nil
 }
 
+// InterfaceValue returns value as an interface{}.
 func (s StringSlice) InterfaceValue() interface{} {
 	return s.value
 }


### PR DESCRIPTION
### Documentation

- [Current `golint` report](https://goreportcard.com/report/github.com/nicheinc/nullable#golint)
- [Private `#back-end-team` slack discussion about the coverage badge](https://nicheinc.slack.com/archives/GGRP9L23D/p1638810792486700)

### Description

This addresses all the warnings in the current `golint` report. It also removes the coveralls.io badge since we couldn't figure out how to grant coveralls access only to public nicheinc repos.

### Testing Considerations

Unit tests should be good enough to merge this, I think. The only code changes are changing a `+= 1` to a `++` and renaming some receivers.

### Versioning

Patch.
