### PR TITLE
arnested/go-version-action doesn't need GITHUB_TOKEN anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       - name: Set Go Versions
         uses: arnested/go-version-action@v1
         id: versions 
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi,

I'm the author of [arnested/go-version-action](https://github.com/marketplace/actions/go-version-action).

The action doesn't need a GITHUB_TOKEN anymore.

Instead of getting the Go releases from git tags using GitHub's API (and thus needing the token to avoid being rate limited) it pulls the versions from https://go.dev/dl/?mode=json&include=all.
