### PR TITLE
Add ApplyPtr and DiffPtr methods to Update[T]

### DIFF
--- a/nup/sliceUpdate_test.go
+++ b/nup/sliceUpdate_test.go
@@ -51,7 +51,7 @@ func TestSliceUpdate_UnmarshalJSON(t *testing.T) {
 			if err := json.Unmarshal([]byte(testCase.json), &dst); err != nil {
 				t.Errorf("Error unmarshaling JSON: %s", err)
 			}
-			if !reflect.DeepEqual(dst.Update, testCase.expected) {
+			if !dst.Update.Equal(testCase.expected) {
 				t.Errorf("Expected: %v. Actual: %v", testCase.expected, dst.Update)
 			}
 		})
@@ -84,7 +84,7 @@ func TestSliceRemoveOrSet(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			actual := SliceRemoveOrSet(testCase.value)
-			if !reflect.DeepEqual(actual, testCase.expected) {
+			if !actual.Equal(testCase.expected) {
 				t.Errorf("Expected: %v. Actual: %v", testCase.expected, actual)
 			}
 		})

--- a/nup/update.go
+++ b/nup/update.go
@@ -147,13 +147,15 @@ func (u Update[T]) Diff(value T) Update[T] {
 // used to omit extraneous updates when applying them would have no effect.
 func (u Update[T]) DiffPtr(value *T) Update[T] {
 	applied := u.ApplyPtr(value)
-	if applied == nil || value == nil {
-		if applied == value {
-			return Noop[T]()
-		}
+	switch {
+	case applied == nil && value == nil:
+		return Noop[T]()
+	case applied == nil || value == nil:
 		return u
+	default:
+		return u.Diff(*value)
 	}
-	return u.Diff(*value)
+
 }
 
 // UnmarshalJSON implements json.Unmarshaler.


### PR DESCRIPTION
### Description

This adds `ApplyPtr` and `DiffPtr` methods, which are similar to `Apply` and `Diff` except that they take a pointer and return `nil` if the operation is `Remove`, rather than `T`'s zero value.

### Testing Considerations

Will be tested via https://github.com/nicheinc/fact/pull/301 (private to `nicheinc`).

### Versioning

Minor.
