### PR TITLE
Add .snyk file to exclude vendor and test files from Snyk Code scanning

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file
+---
+exclude:
+  # Exclusion syntax: https://docs.snyk.io/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import#syntax-to-use-to-exclude-files-and-directories-from-snyk-code-testing
+  global:
+    # The vendor directory corresponds to the go.mod, which Snyk already scans
+    # for vulnerable versions of dependencies.
+    - vendor
+    # Test files are excluded from non-test builds and cannot affect production.
+    - "*_test.go"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+.snyk @nicheinc/sre @nicheinc/delta-be


### PR DESCRIPTION
### Documentation

- [`DELTA-2861`: Add .snyk files to all relevant Core BE repos](https://nicheinc.atlassian.net/browse/DELTA-2861)
- Pilot PR: https://github.com/nicheinc/pando-api/pull/313

### Description

This PR adds a `.snyk` file to exclude `vendor` and `*_test.go` files from Snyk Code scanning.

### Deployment

No deployment necessary.

### Versioning

N/A
